### PR TITLE
ci: fix .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,11 @@
 {
-  "branches": ["main"]
+  "branches": ["main"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits"
+    }],
+    "@semantic-release/github"
+  ],
+  "repositoryUrl": "https://github.com/virtool/virtool-operator.git",
+  "tagFormat": "${version}"
 }
-


### PR DESCRIPTION
Current configuration is trying to publish npm package by default. I am making an assumption here, but clues point that way.